### PR TITLE
Fixed ReferenceError:configDef not defined

### DIFF
--- a/generator/extjs.js.tpl
+++ b/generator/extjs.js.tpl
@@ -61,7 +61,7 @@
       var parentDefinitionName = className.replace(/\./g, '_') + '_cfg';
       classConfigDef = cx.definitions.extjs[parentDefinitionName];
     } else {
-      configDef = cx.definitions.Ext_cfg;
+      classConfigDef = cx.definitions.Ext_cfg;
     }
     return classConfigDef;
   }


### PR DESCRIPTION
I think, there is a logical mistake in the template code. I was getting configDef error continuously. I was not able to type anyting afterwards, even after using bundled plugins.
Fixed it finally after 4 hrs. Phew.

Version Details:
- Sublime Text (v. 3126)
- tern (v. 0.21.0) (shipped with tern_for_sublime)
- extjs plugin (tried with 4.2.1 (bundled), 4.2.2 (custom generated as specified)).

Screenshot attached for the error:
![error](https://user-images.githubusercontent.com/9387023/29780118-3cc31b88-8c32-11e7-8b15-20423e893c3b.PNG)
